### PR TITLE
Fixes issue #207

### DIFF
--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -57,10 +57,15 @@ function stripExtension(filePath: string) {
 }
 
 async function cmdShim(src: string, dest: string) {
-  const currentShimTarget = path.resolve(
-    path.dirname(src),
-    await readCmdShim(src)
-  );
+  var currentShimTarget = src;
+  try{
+    var currentShimTarget = path.resolve(
+      path.dirname(src),
+      await readCmdShim(src)
+    );
+  }catch(err){
+    
+  }
   await promisify(cb => _cmdShim(currentShimTarget, stripExtension(dest), cb));
 }
 


### PR DESCRIPTION
In certain situations where you have internal workspace dependencies you dont have shims created so calling "readCmdShim" expects to read a shim file. Instead we just create the shim file using the file referenced in "src".